### PR TITLE
Update README branding, SDK version, and formatting

### DIFF
--- a/SoftwareEngineerInterview/CSharp/README.md
+++ b/SoftwareEngineerInterview/CSharp/README.md
@@ -1,15 +1,25 @@
 # CSharp Project
 
 ## Requirements
-> Visual Studio Code
-> Dotnet SDK 3.1
+```
+Visual Studio Code
+Dotnet SDK 6.0
+```
 
 ## Install
-> TODO
+```
+cd Zip.InstallmentsService
+dotnet restore
+```
 
 ## Quick Start
-> TODO
+```
+cd Zip.InstallmentsService
+dotnet run
+```
 
 ## Run Tests
-> cd QuadPay.InstallmentsService
-> dotnet test QuadPay.InstallmentsService.sln
+```
+cd Zip.InstallmentsService
+dotnet test Zip.InstallmentsService.sln
+```


### PR DESCRIPTION
I noticed some old branding and an older SDK version are still in place in the CSharp README.md file. I've updated them in the fork I was using to play around with the assignment.

I also noticed block quotes were being used instead of code blocks, which GitHub didn't like on the web interface, so I've changed them here to allow copy/pasting into a terminal. The alternative solution would be to rewrite them a little something like:

```markdown
> cd Zip.InstallmentsService && dotnet test Zip.InstallmentsService.sln
```

...but it seemed like the original intent was to have them on different lines, so I've preserved that here.